### PR TITLE
Feat/image and slopify logo

### DIFF
--- a/src/shared/ui/data-display/Image/Image.stories.tsx
+++ b/src/shared/ui/data-display/Image/Image.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Image } from "./Image";
+
+const meta = {
+  args: {
+    src: "https://picsum.photos/600/600",
+    alt: "",
+    width: 600,
+    height: 600,
+  },
+  component: Image,
+} satisfies Meta<typeof Image>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/shared/ui/data-display/Image/Image.tsx
+++ b/src/shared/ui/data-display/Image/Image.tsx
@@ -1,0 +1,15 @@
+import NextImage from "next/image";
+import React from "react";
+
+/**
+ * An image component that uses Next.js's image optimization capabilities.
+ *
+ * @see https://nextjs.org/docs/basic-features/image-optimization
+ * @see https://nextjs.org/docs/basic-features/image-component
+ */
+export const Image = React.forwardRef<
+  React.ElementRef<typeof NextImage>,
+  React.ComponentPropsWithoutRef<typeof NextImage>
+>(function Image(props, ref) {
+  return <NextImage {...props} ref={ref} />;
+});

--- a/src/shared/ui/data-display/SlopifyLogo/SlopifyLogo.stories.tsx
+++ b/src/shared/ui/data-display/SlopifyLogo/SlopifyLogo.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { SlopifyLogo } from "./SlopifyLogo";
+
+const meta = {
+  component: SlopifyLogo,
+} satisfies Meta<typeof SlopifyLogo>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/shared/ui/data-display/SlopifyLogo/SlopifyLogo.tsx
+++ b/src/shared/ui/data-display/SlopifyLogo/SlopifyLogo.tsx
@@ -1,0 +1,44 @@
+import { cva, type VariantProps } from "cva";
+
+import { Image } from "../Image/Image";
+
+const slopifyLogoVariants = cva({
+  base: `flex items-center gap-spacing-tighter-4 font-bold text-text-base`,
+
+  defaultVariants: {
+    size: "medium",
+  },
+
+  variants: {
+    size: {
+      medium: `text-font-size-base`,
+      large: `text-font-size-larger`,
+    },
+  },
+});
+
+interface SlopifyLogoProps extends VariantProps<typeof slopifyLogoVariants> {
+  /**
+   * Class name to add to the component
+   */
+  className?: string;
+}
+
+/**
+ * Displays the Slopify logo
+ */
+export function SlopifyLogo({ className, size }: SlopifyLogoProps) {
+  return (
+    <div className={slopifyLogoVariants({ className, size })}>
+      <Image
+        width={40}
+        height={40}
+        style={{ width: "1.5em" }}
+        src="/logo.png"
+        alt="Slopify logo"
+      />
+
+      <span>Slopify</span>
+    </div>
+  );
+}

--- a/src/shared/ui/data-display/index.ts
+++ b/src/shared/ui/data-display/index.ts
@@ -1,0 +1,2 @@
+export { Image } from "./Image/Image";
+export { SlopifyLogo } from "./SlopifyLogo/SlopifyLogo";

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -1,3 +1,4 @@
+export * from "./data-display";
 export * from "./inputs";
 export * from "./layouts";
 export * from "./surfaces";

--- a/src/shared/ui/inputs/Switch/Switch.tsx
+++ b/src/shared/ui/inputs/Switch/Switch.tsx
@@ -3,6 +3,7 @@
 import * as SwitchPrimitives from "@radix-ui/react-switch";
 import React from "react";
 import { twJoin } from "tailwind-merge";
+
 import { disabledInput, focusRing } from "../../utils";
 
 /**

--- a/src/shared/ui/layouts/MainLayout/SideBar.tsx
+++ b/src/shared/ui/layouts/MainLayout/SideBar.tsx
@@ -1,4 +1,3 @@
-import Image from "next/image";
 import {
   HiHome,
   HiMagnifyingGlass,
@@ -7,38 +6,36 @@ import {
   HiRectangleStack,
 } from "react-icons/hi2";
 
-import { Button, IconButton, Paper } from "@/shared/ui";
+import { SlopifyLogo } from "../../data-display";
+import { Button, IconButton } from "../../inputs";
+import { Paper } from "../../surfaces";
 
 export function SideBar() {
   return (
     <nav className="flex h-full w-[345px] shrink-0 flex-col">
-      <Paper className="shrink-0">
-        <div className="flex pl-spacing-base font-bold text-text-base">
-          <Image width={28} height={28} src="/logo.png" alt="Slopify logo" />
+      <Paper className="shrink-0 px-spacing-looser pb-spacing-base pt-spacing-looser">
+        <SlopifyLogo />
 
-          <span className="ml-spacing-tighter-5">Slopify</span>
-        </div>
-
-        <ul className="mt-spacing-tighter space-y-spacing-base px-spacing-base py-spacing-tighter-2 text-text-subdued">
+        <ul className="mt-spacing-looser space-y-spacing-base text-text-subdued">
           <li>
             <a
               href="#"
-              className="inline-flex items-center font-bold transition-colors duration-200 hover:text-text-base"
+              className="inline-flex items-center space-x-spacing-base font-bold transition-colors duration-200 hover:text-text-base"
             >
-              <HiHome className="size-6" />
+              <HiHome className="text-[1.5em]" />
 
-              <span className="ml-spacing-base">Accueil</span>
+              <span>Accueil</span>
             </a>
           </li>
 
           <li>
             <a
               href="#"
-              className="inline-flex items-center font-bold transition-colors duration-200 hover:text-text-base"
+              className="inline-flex items-center space-x-spacing-base font-bold transition-colors duration-200 hover:text-text-base"
             >
-              <HiMagnifyingGlass className="size-6" />
+              <HiMagnifyingGlass className="text-[1.5em]" />
 
-              <span className="ml-spacing-base">Rechercher</span>
+              <span>Rechercher</span>
             </a>
           </li>
         </ul>
@@ -48,14 +45,16 @@ export function SideBar() {
         <header className="mb-spacing-looser flex justify-between px-spacing-tighter">
           <a
             href="#"
-            className="inline-flex items-center font-bold text-text-subdued transition-colors duration-200 hover:text-text-base"
+            className="inline-flex items-center space-x-spacing-tighter font-bold text-text-subdued transition-colors duration-200 hover:text-text-base"
           >
-            <HiRectangleStack className="size-6" />
+            <HiRectangleStack className="text-[1.5em]" />
 
-            <span className="ml-spacing-tighter">Bibliothèque</span>
+            <span>Bibliothèque</span>
           </a>
 
-          <IconButton icon={<HiPlus className="size-6 text-text-subdued" />} />
+          <IconButton
+            icon={<HiPlus className="text-[1.5em] text-text-subdued" />}
+          />
         </header>
 
         <div className="grow space-y-spacing-looser overflow-scroll">

--- a/src/shared/ui/layouts/TopBarCenteredCardLayout/TopBar.tsx
+++ b/src/shared/ui/layouts/TopBarCenteredCardLayout/TopBar.tsx
@@ -1,13 +1,9 @@
-import Image from "next/image";
+import { SlopifyLogo } from "../../data-display";
 
 export function TopBar() {
   return (
     <div className="flex flex-row items-center py-spacing-looser-2 pl-spacing-looser-3">
-      <Image width={40} height={40} src="/logo.png" alt="Slopify logo" />
-
-      <span className="ml-spacing-tighter-4 text-font-size-larger font-bold text-text-base">
-        Slopify
-      </span>
+      <SlopifyLogo size="large" />
     </div>
   );
 }

--- a/src/shared/ui/surfaces/Card/Card.tsx
+++ b/src/shared/ui/surfaces/Card/Card.tsx
@@ -1,7 +1,7 @@
-import Image from "next/image";
 import { IoMdPlay } from "react-icons/io";
 import { twJoin } from "tailwind-merge";
 
+import { Image } from "../../data-display";
 import { IconButton } from "../../inputs";
 import { Paper } from "../Paper/Paper";
 
@@ -24,7 +24,7 @@ export function Card({ roundedPicture }: CardProps) {
             src="https://picsum.photos/300/300"
             width={300}
             height={300}
-            alt="card picture"
+            alt=""
             className={twJoin(
               `rounded-border-radius-larger`,
               roundedPicture && `rounded-full`,
@@ -38,7 +38,7 @@ export function Card({ roundedPicture }: CardProps) {
           />
         </div>
         <div className="mt-spacing-base">
-          <a href="" className="font-bold text-text-base">
+          <a href="#" className="font-bold text-text-base">
             Todays Top Hits
           </a>
           <span className="line-clamp-2 text-font-size-smaller font-semibold text-text-subdued">

--- a/src/shared/ui/surfaces/Paper/Paper.stories.tsx
+++ b/src/shared/ui/surfaces/Paper/Paper.stories.tsx
@@ -3,12 +3,8 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Paper } from "./Paper";
 
 const meta = {
-  args: { children: <>Click me!</> },
-  argTypes: {
-    variant: {
-      options: ["flat", "tinted", "elevated"],
-      control: { type: "select" },
-    },
+  args: {
+    children: "This is the paper component",
   },
   component: Paper,
 } satisfies Meta<typeof Paper>;
@@ -21,11 +17,7 @@ export const Default: Story = {
   render: function Render(args) {
     return (
       <div className="bg-background-base p-spacing-base">
-        <Paper {...args}>
-          Lorem ipsum dolor sit amet, consectetur adipisicing elit. Libero
-          doloremque facilis natus harum minima, sequi exercitationem. Eum,
-          natus!
-        </Paper>
+        <Paper {...args} />
       </div>
     );
   },


### PR DESCRIPTION
## General descrption

1. Add `<Image />` component that inherit from `next/image`
    - We want to centralise common images behaviour in only one component to bring good defaults if needed
    - Maybe later we'd want to use another Image component and not the one provided by Next? Migration would be easier too <3
2. Add `<SlopifyLogo />` component that… displays the Slopify logo (uses an `.svg` instead of a `.png`)
3. Implement both components where needed
4. Small refactors here and there

