### PR TITLE
feat(mainlayout): add navbar connected

### DIFF
--- a/src/shared/ui/layouts/MainLayout/NavBar.stories.tsx
+++ b/src/shared/ui/layouts/MainLayout/NavBar.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { NavBar } from "./NavBar";
+
+const meta = {
+  component: NavBar,
+} satisfies Meta<typeof NavBar>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/shared/ui/layouts/MainLayout/NavBar.tsx
+++ b/src/shared/ui/layouts/MainLayout/NavBar.tsx
@@ -29,6 +29,7 @@ export function NavBar() {
           </li>
         </ul>
       </nav>
+
       <nav>
         <ul className="flex items-center md:divide-x md:divide-decorative-base">
           <li className="hidden md:mr-spacing-base md:list-item">

--- a/src/shared/ui/layouts/MainLayout/NavBarConnected.stories.tsx
+++ b/src/shared/ui/layouts/MainLayout/NavBarConnected.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { NavBarConnected } from "./NavBarConnected";
+
+const meta = {
+  component: NavBarConnected,
+} satisfies Meta<typeof NavBarConnected>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/shared/ui/layouts/MainLayout/NavBarConnected.tsx
+++ b/src/shared/ui/layouts/MainLayout/NavBarConnected.tsx
@@ -1,0 +1,78 @@
+import { HiChevronLeft, HiChevronRight } from "react-icons/hi2";
+
+import { CiSettings } from "react-icons/ci";
+import { GoBell } from "react-icons/go";
+import { LuArrowDownCircle } from "react-icons/lu";
+import { IconButton } from "../../inputs";
+import { buttonVariants } from "../../inputs/Button/Button";
+import { Link } from "../../navigation";
+
+export function NavBarConnected() {
+  return (
+    <div className="flex items-center justify-between px-spacing-base">
+      <nav>
+        <ul className="flex space-x-spacing-tighter-3">
+          <li>
+            {/* TODO: replace with Link */}
+            <IconButton
+              disabled
+              size="small"
+              tooltip="Go back"
+              variant="over-media"
+            >
+              <HiChevronLeft />
+            </IconButton>
+          </li>
+
+          <li>
+            {/* TODO: replace with Link */}
+            <IconButton size="small" tooltip="Go forward" variant="over-media">
+              <HiChevronRight />
+            </IconButton>
+          </li>
+        </ul>
+      </nav>
+
+      <nav>
+        <ul className="flex items-center gap-spacing-tighter-2">
+          <li>
+            <Link
+              href="/"
+              className={buttonVariants({
+                size: "medium",
+                variant: "inverted-light",
+              })}
+            >
+              Discover Premium
+            </Link>
+          </li>
+          <li>
+            <Link
+              href="/"
+              className={buttonVariants({
+                size: "medium",
+                variant: "over-media",
+              })}
+            >
+              <LuArrowDownCircle />
+              Install app
+            </Link>
+          </li>
+          <li>
+            <Link href="/">
+              <IconButton size="small" tooltip="news" variant="over-media">
+                <GoBell />
+              </IconButton>
+            </Link>
+          </li>
+          {/* TODO: replace with DropdownMenu component when it's ready */}
+          <li>
+            <IconButton size="small" tooltip="User name" variant="accent">
+              <CiSettings />
+            </IconButton>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

⚠️ The purpose of this component is not to remain but to present the elements to be displayed in the navigation bar when the user's state is managed.

- Add a new **`NavBarConnected`** component which displays new content when the user is logged in
- Add his stories
- Add **`NavBar`** stories

<img width="1129" alt="Capture d’écran 2024-03-25 à 12 38 27" src="https://github.com/Anto2441/slopify/assets/47365465/740b925e-2535-4664-ba02-557876e46356">

