### PR TITLE
Feat/http service spotify api

### DIFF
--- a/src/shared/http/HttpService.ts
+++ b/src/shared/http/HttpService.ts
@@ -1,0 +1,63 @@
+import type { IHttpService } from "./IHttpService";
+import type {
+  HttpError,
+  HttpOptions,
+  HttpResource,
+  HttpResponse,
+} from "./types";
+
+interface HttpServiceProps {
+  /**
+   * The base URL for the HTTP requests.
+   *
+   * All HTTP requests made by this service will be relative to this URL.
+   *
+   * @example "https://api.example.com"
+   */
+  baseUrl: string;
+}
+
+/**
+ * Service for making HTTP requests.
+ *
+ * This service is responsible for making HTTP requests and
+ * handling the response.
+ */
+export class HttpService implements IHttpService {
+  constructor(private readonly props: HttpServiceProps) {}
+
+  /**
+   * Sends an HTTP request and returns a promise that resolves to the
+   * response data.
+   */
+  async request<TData>(
+    resource: HttpResource,
+    options: HttpOptions,
+  ): Promise<HttpResponse<TData>> {
+    return fetch(this.props.baseUrl + resource, options)
+      .then((response) => {
+        if (!response.ok) {
+          const httpError: HttpError = {
+            status: response.status,
+            message: response.statusText,
+          };
+
+          throw httpError;
+        }
+
+        return response.json();
+      })
+      .then((data: TData) => ({ data, error: null }))
+      .catch((error: HttpError) => ({ data: null, error }));
+  }
+
+  /**
+   * Sends an asynchronous GET request to the specified resource.
+   */
+  async get<TData>(
+    resource: HttpResource,
+    options?: Omit<HttpOptions, "body" | "method">,
+  ) {
+    return this.request<TData>(resource, { ...options, method: "GET" });
+  }
+}

--- a/src/shared/http/IHttpService.ts
+++ b/src/shared/http/IHttpService.ts
@@ -1,0 +1,25 @@
+import type { HttpOptions, HttpResource, HttpResponse } from "./types";
+
+/**
+ * Represents a service for making HTTP requests.
+ *
+ * This interface defines the contract for a service that is responsible
+ * for making HTTP requests and handling the response.
+ */
+export interface IHttpService {
+  /**
+   * Sends an asynchronous GET request to the specified resource.
+   */
+  get: <TData>(
+    resource: HttpResource,
+    options?: Omit<HttpOptions, "body" | "method">,
+  ) => Promise<HttpResponse<TData>>;
+
+  /**
+   * Sends an HTTP request to the specified resource.
+   */
+  request: <TData>(
+    resource: HttpResource,
+    options: HttpOptions,
+  ) => Promise<HttpResponse<TData>>;
+}

--- a/src/shared/http/index.ts
+++ b/src/shared/http/index.ts
@@ -1,0 +1,8 @@
+export { HttpService } from "./HttpService";
+export type { IHttpService } from "./IHttpService";
+export type {
+  HttpError,
+  HttpOptions,
+  HttpResource,
+  HttpResponse,
+} from "./types";

--- a/src/shared/http/types.ts
+++ b/src/shared/http/types.ts
@@ -1,0 +1,76 @@
+/**
+ * Type for the HTTP resource.
+ *
+ * This type represents a string that represents the resource to be accessed
+ * over HTTP. It should be a valid URI, including the path, query parameters,
+ * and any other part of the URI.
+ *
+ * @example "/users"
+ */
+export type HttpResource = string;
+
+/**
+ * Options for making an HTTP request.
+ *
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters Fetch API parameters}
+ */
+export type HttpOptions = {
+  /**
+   * The body contents of the request.
+   */
+  body?: BodyInit | null;
+  /**
+   * The credentials to use in the request.
+   *
+   * Defaults to `omit` which means the browser will not send or
+   * include cookies or authentication information.
+   *
+   * See {@link https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials Request.credentials}.
+   */
+  credentials?: RequestCredentials;
+  /**
+   * The headers to include in the request.
+   *
+   * The `Authorization` header, if included, will contain a bearer token.
+   * See {@link https://developer.mozilla.org/en-US/docs/Web/API/Headers HeadersInit}.
+   */
+  headers?: HeadersInit & { Authorization?: string };
+  /**
+   * The HTTP method to use in the request.
+   *
+   * Possible values are `DELETE`, `GET`, `HEAD`, `OPTIONS`, `PATCH`, `POST`, or `PUT`.
+   * See {@link https://developer.mozilla.org/en-US/docs/Web/API/Request/method Request.method}.
+   */
+  method: "DELETE" | "GET" | "HEAD" | "OPTIONS" | "PATCH" | "POST" | "PUT";
+  /**
+   * A signal which can be used to abort the request.
+   *
+   * See {@link https://developer.mozilla.org/en-US/docs/Web/API/AbortController AbortController}.
+   */
+  signal?: AbortSignal | null;
+};
+
+/**
+ * Represents the error response of an HTTP request.
+ */
+export type HttpError = {
+  /**
+   * The HTTP status code of the response.
+   */
+  status: number;
+  /**
+   * A human-readable description of the error.
+   */
+  message: string;
+};
+
+/**
+ * The type of the HTTP response.
+ *
+ * It represents the possible outcomes of an HTTP request.
+ *
+ * @template TData - The type of the data included in the response.
+ */
+export type HttpResponse<TData> =
+  | { data: TData; error: null }
+  | { data: null; error: HttpError };

--- a/src/shared/spotify/web-api/ISpotifyWebApi.ts
+++ b/src/shared/spotify/web-api/ISpotifyWebApi.ts
@@ -1,0 +1,17 @@
+import type { HttpOptions, HttpResource, HttpResponse } from "@/shared/http";
+
+/**
+ * Interface representing a Spotify Web API client.
+ *
+ * This interface defines the contract for a client that can make
+ * requests to the Spotify Web API and handle the responses.
+ */
+export interface ISpotifyWebApi {
+  /**
+   * Sends an asynchronous GET request to the specified resource.
+   */
+  get<TData>(
+    resource: HttpResource,
+    options?: HttpOptions,
+  ): Promise<HttpResponse<TData>>;
+}

--- a/src/shared/spotify/web-api/SpotifyWebApi.ts
+++ b/src/shared/spotify/web-api/SpotifyWebApi.ts
@@ -1,0 +1,86 @@
+import { getServerSession } from "@/shared/auth/next";
+import {
+  HttpService,
+  type HttpOptions,
+  type HttpResource,
+  type HttpResponse,
+  type IHttpService,
+} from "@/shared/http";
+
+import { ISpotifyWebApi } from "./ISpotifyWebApi";
+
+// TODO: Move it to and grab it from a AuthService instead?
+type IAuthService = Promise<{ accessToken?: string } | null>;
+
+interface SpotifyWebApiDeps {
+  /**
+   * The HTTP service to use for making HTTP requests.
+   *
+   * @see {@link IHttpService}
+   */
+  httpService: IHttpService;
+  /**
+   * The authentication service to use for obtaining the access token.
+   *
+   * This promise resolves to an object with an optional `accessToken` property.
+   * The `accessToken` is used as the bearer token in the `Authorization` header
+   * of the HTTP requests made by `httpService`.
+   */
+  authService: IAuthService;
+}
+
+/**
+ * The `SpotifyWebApi` class is a client for making requests to the Spotify Web API.
+ *
+ * It uses an {@link IHttpService} to make HTTP requests and an {@link IAuthService} to pass
+ * the Authorization token with each request.
+ */
+export class SpotifyWebApi implements ISpotifyWebApi {
+  constructor(
+    private readonly deps: SpotifyWebApiDeps = {
+      httpService: new HttpService({ baseUrl: "https://api.spotify.com/v1" }),
+      authService: getServerSession(),
+    },
+  ) {}
+
+  /**
+   * Sends an HTTP request and returns a promise that resolves to the response data.
+   *
+   * The `accessToken` property of the session object obtained using the auth service
+   * is used as the bearer token in the `Authorization` header of the HTTP request.
+   */
+  private async request<TData>(
+    resource: HttpResource,
+    options: HttpOptions,
+  ): Promise<HttpResponse<TData>> {
+    const session = await this.deps.authService;
+
+    if (!session?.accessToken) {
+      return Promise.resolve({
+        data: null,
+        error: { status: 401, message: "Unauthorized" },
+      });
+    }
+
+    return this.deps.httpService.request(resource, {
+      ...options,
+      credentials: "include",
+      headers: {
+        ...options?.headers,
+        ...(session?.accessToken && {
+          Authorization: `Bearer ${session?.accessToken}`,
+        }),
+      },
+    });
+  }
+
+  /**
+   * Sends an asynchronous GET request to the specified resource.
+   */
+  async get<TData>(
+    resource: HttpResource,
+    options?: Omit<HttpOptions, "body" | "method">,
+  ) {
+    return this.request<TData>(resource, { ...options, method: "GET" });
+  }
+}

--- a/src/shared/spotify/web-api/index.ts
+++ b/src/shared/spotify/web-api/index.ts
@@ -1,0 +1,2 @@
+export type { ISpotifyWebApi } from "./ISpotifyWebApi";
+export { SpotifyWebApi } from "./SpotifyWebApi";


### PR DESCRIPTION
## General Description

1. Add an `HTTPService` to the application. 
    - This service will be responsible for making HTTP requests in our app.
2. Add a `SpotifyWebApi` to the application. 
    - This class will be responsible for making HTTP requests to the Spotify Web API specifically.

Note: Not sure how we'll deal with tests… yet. I'll add them in a following PR (#babysteps)