### PR TITLE
Refactor/improve a11y

### DIFF
--- a/src/library/layouts/library/ui/TopBar.tsx
+++ b/src/library/layouts/library/ui/TopBar.tsx
@@ -66,11 +66,9 @@ export async function TopBar() {
             </li>
 
             <li>
-              <Link href="#">
-                <IconButton size="small" tooltip="news" variant="over-media">
-                  <GoBell />
-                </IconButton>
-              </Link>
+              <IconButton size="small" tooltip="news" variant="over-media">
+                <GoBell />
+              </IconButton>
             </li>
 
             <li>{session.user && <UserDropdownMenu user={session.user} />}</li>

--- a/src/shared/ui/inputs/IconButton/IconButton.tsx
+++ b/src/shared/ui/inputs/IconButton/IconButton.tsx
@@ -42,7 +42,7 @@ type IconButtonProps = React.ComponentPropsWithoutRef<"button"> &
     /**
      * The text content of the tooltip displayed on hover. It is mandatory for accessibility reasons.
      */
-    tooltip: React.ReactNode;
+    tooltip: string;
   };
 
 /**
@@ -58,6 +58,7 @@ export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
         <TooltipTrigger asChild>
           <button
             {...props}
+            aria-label={tooltip}
             className={iconButtonVariants({
               className,
               disabled: props.disabled,

--- a/src/shared/ui/inputs/Slider/Slider.tsx
+++ b/src/shared/ui/inputs/Slider/Slider.tsx
@@ -3,6 +3,7 @@
 import * as SliderPrimitive from "@radix-ui/react-slider";
 import * as React from "react";
 import { twJoin } from "tailwind-merge";
+
 import { disabledInput } from "../../utils";
 
 /**
@@ -28,7 +29,9 @@ export const Slider = React.forwardRef<
       <SliderPrimitive.Track className="relative h-1 w-full grow overflow-hidden rounded-full bg-essential-subdued">
         <SliderPrimitive.Range className="absolute h-full rounded-full bg-color-base group-hover:bg-color-bright-accent" />
       </SliderPrimitive.Track>
+
       <SliderPrimitive.Thumb
+        aria-label="Slider’s thumb"
         className={twJoin(
           "block h-4 w-4 cursor-pointer rounded-full bg-color-base opacity-0 shadow transition-colors focus-visible:outline-none focus-visible:ring-1 group-hover:opacity-100",
           disabledInput(),


### PR DESCRIPTION
## General description

Improve accessibility following notices raised by [Lighthouse](https://developer.chrome.com/docs/lighthouse/overview), [Axe](https://www.deque.com/axe/), [Tanaguru](https://www.tanaguru.com/) and [Wave](https://wave.webaim.org/) tools.

1. Add `aria-label` attribute to the `<IconButton />` (same text as tooltip). Fixes #52 

2. Remove `<Link />` wrapping the `bell` button of the library's top bar.

3. Add `aria-label` attribute to thte shumb of the `<Slider />` component.